### PR TITLE
feat: GECK protocol v1.3

### DIFF
--- a/GECK/GECK_Macro_v1.3.md
+++ b/GECK/GECK_Macro_v1.3.md
@@ -1,0 +1,470 @@
+# GECK_Macro v1.3
+## Garden of Eden Creation Kit — LLM-Assisted Development Protocol
+### Protocol Version: 1.3
+
+---
+
+## Overview
+
+GECK gives CLI LLM agents structured memory, task management, and human oversight across sessions. v1.3 reorganizes memory into **episodic** (chronological log) and **semantic** (decisions, learnings) layers, adopts **typed addressable artifacts** (Task IDs, Decision IDs, Learning IDs), and scales the active context to a declared **context budget** so the protocol works for both small-window and frontier-window models.
+
+### Design Principles
+1. **Minimal viable overhead** — Documentation should not exceed the work itself
+2. **Single source of truth** — One authoritative location for each type of information
+3. **Episodic vs. semantic memory** — Logs record *what happened*; decisions and learnings record *what is now true*
+4. **Addressable artifacts** — Tasks, decisions, and learnings have stable IDs and are referenced, not re-derived
+5. **Drift resistance** — Protocol detects and halts goal erosion at session start
+6. **Git-native** — All artifacts are plain text and diff cleanly
+7. **Stack agnostic** — Applicable to any technology ecosystem
+8. **Scales to context** — Active read set shrinks for small models, expands for large ones
+
+---
+
+## Project Structure
+
+```
+project_root/
+├── LLM_init.md              # Project goals, constraints, context budget (human-authored)
+└── GECK/
+    ├── GECK_Inst.md         # Agent instructions (reference doc)
+    ├── tasks.md             # Working memory — typed tasks with state
+    ├── log.md               # Episodic memory — last N entries (N from context budget)
+    ├── log_index.jsonl      # Machine-readable index of every entry, ever
+    ├── log_archive/         # log_YYYY-MM.md rollovers
+    ├── decisions.md         # Index of decision records (one line each)
+    ├── decisions/           # DECISION-NNN-slug.md per decision
+    ├── learnings.md         # Index of learning records (one line each)
+    ├── learnings/           # LEARNING-NNN-slug.md per learning
+    └── env.md               # Environment snapshot
+```
+
+**Naming change from v1.2:** the folder is now `GECK/` (was `LLM_GECK/`). The `LLM_` prefix was redundant — the entire repo is for LLM use.
+
+---
+
+## Memory Model (the v1.3 reorganization)
+
+| Layer | File(s) | Read at session start | Write cadence | Purpose |
+|-------|---------|----------------------|---------------|---------|
+| **Goals** | `LLM_init.md` | Always | Human only | North star |
+| **Working memory** | `tasks.md` | Always | Every turn | What to do now |
+| **Semantic — decisions** | `decisions.md` + `decisions/` | Index always; files on demand | When a decision is made | Why we chose X |
+| **Semantic — learnings** | `learnings.md` + `learnings/` | Index always; files on demand | When something broke or surprised | Don't redo the bad thing |
+| **Episodic** | `log.md` (active) | Last N entries | Every turn | Narrative continuity |
+| **Episodic archive** | `log_index.jsonl`, `log_archive/` | Index queried on demand | Rollover when active log exceeds budget | Full history for audit & targeted recall |
+| **Environment** | `env.md` | As needed | When env changes | Compatibility decisions |
+
+The agent does **not** re-read the full log every session. It reads the index and drills into specific archived entries only when a current task references them.
+
+---
+
+## Per-Record Files (Claude Code memory style, clean-room adapted)
+
+Decisions and learnings are stored as one file per record, with a flat-text index pointing to each file. This pattern (borrowed in spirit from Claude Code's auto-memory system) gives:
+
+- Individual addressability (cite by ID, edit in isolation)
+- Small diffs (a new decision doesn't churn a 500-line file)
+- Cheap session-start reads (the index is one line per record)
+- Drill-down on demand (only load the specific file you need)
+
+### `decisions/DECISION-NNN-<slug>.md`
+
+```markdown
+---
+id: DECISION-001
+title: Choose Zustand over React Context for state management
+date: 2026-04-17T14:32:00Z
+status: active        # active | superseded
+related-tasks: [TASK-004]
+related-decisions: []
+superseded-by: null
+---
+
+**Decision:** Use Zustand for client state.
+
+**Why:** App will have complex state interactions across many components.
+React Context re-renders too aggressively at scale and adds boilerplate
+for cross-cutting state.
+
+**Consequences:**
+- New runtime dependency (~1KB gzipped, acceptable)
+- Team must learn Zustand idioms (low ramp)
+- Refactoring Redux-style slices later is straightforward
+```
+
+### `decisions.md` (index)
+
+```markdown
+# Decisions — <Project Name>
+
+*One line per decision record. Drill into the file for rationale.*
+
+- [DECISION-001](decisions/DECISION-001-zustand-over-context.md) — Use Zustand for client state. (active)
+- [DECISION-002](decisions/DECISION-002-postgres-over-sqlite.md) — Postgres for persistence. (active)
+```
+
+### `learnings/LEARNING-NNN-<slug>.md`
+
+```markdown
+---
+id: LEARNING-001
+title: Vite dev server proxy needs explicit Host header rewrite
+date: 2026-04-17T16:11:00Z
+related-tasks: [TASK-007]
+---
+
+**Rule:** When proxying to a backend that validates Host, set
+`changeOrigin: true` AND `headers.Host` explicitly in `vite.config.ts`.
+
+**Why:** Backend rejected requests with 421 Misdirected Request because
+`changeOrigin: true` alone forwards the upstream Host but leaves cookies
+scoped to the dev origin.
+
+**How to apply:** Any new dev-only proxy rule in this project.
+```
+
+### `learnings.md` (index)
+
+```markdown
+# Learnings — <Project Name>
+
+*One line per learning. Drill into the file for context.*
+
+- [LEARNING-001](learnings/LEARNING-001-vite-proxy-host.md) — Vite proxy needs explicit Host header.
+```
+
+---
+
+## Tasks (typed, addressable, state-machined)
+
+### `tasks.md` format
+
+```markdown
+# Tasks — <Project Name>
+
+**Last Updated:** <ISO timestamp>
+
+## Legend
+
+- `[ ]` proposed/accepted (not started)
+- `[~]` active (in progress)
+- `[!:reason]` blocked (reason required)
+- `[x]` completed (immutable; cite log entry)
+
+State transitions are forward-only (or to blocked). Completed tasks are not re-opened — file a new task instead.
+
+## Current Sprint
+
+- [~] TASK-001 | TYPE: feature | SCOPE: medium | OWNER: agent
+  - Implement user authentication endpoint
+  - Subtask: write Pydantic models (nested bullets give the tree shape)
+  - Subtask: add JWT middleware
+- [!:waiting on DECISION-003] TASK-002 | TYPE: refactor | SCOPE: small | OWNER: agent
+  - Extract DB session helper from views
+
+## Backlog
+
+- [ ] TASK-003 | TYPE: research | SCOPE: small | OWNER: human
+  - Compare Stripe vs. Lemon Squeezy
+
+## Completed (Recent)
+
+- [x] TASK-000 | TYPE: chore | SCOPE: small — Entry #2
+```
+
+### Field semantics
+
+| Field | Allowed values |
+|-------|----------------|
+| TYPE | `feature` \| `fix` \| `refactor` \| `research` \| `chore` \| `docs` \| `test` |
+| SCOPE | `small` \| `medium` \| `large` |
+| OWNER | `agent` \| `human` |
+
+### Rules
+
+- Task IDs are sequential and never reused.
+- Log entries MUST reference the TASK-IDs they touched.
+- A `[x]` completion MUST cite the log entry number (`— Entry #N`).
+- A `[!:...]` block MUST include a reason (decision pending, external blocker, etc.).
+
+---
+
+## Log (episodic, tiered, agent-optimized)
+
+### Active `log.md` — tightened per-turn entry
+
+```markdown
+# Session Log — <Project Name>
+
+*Append only. Older entries roll to log_archive/. Full history queryable via log_index.jsonl.*
+
+---
+
+## Entry #N — <ISO timestamp> — touched: TASK-001, TASK-004
+- Did: <one line summary of what changed>
+- Files: <paths, comma-separated>
+- State: CONTINUE | WAIT | ROLLBACK
+- Refs: DECISION-002, LEARNING-001    (omit line if none)
+- Next: <one line — what comes next>
+```
+
+That's the whole entry. Long-form audit data, if anyone wants it, lives in commit messages and PR descriptions — not duplicated here.
+
+### `log_index.jsonl` — one line per entry, ever
+
+```jsonl
+{"id":1,"ts":"2026-04-17T14:00:00Z","tasks":["TASK-001"],"decisions":[],"learnings":[],"files":["src/auth.py"],"state":"CONTINUE","summary":"Scaffolded auth route"}
+{"id":2,"ts":"2026-04-17T15:20:00Z","tasks":["TASK-001"],"decisions":["DECISION-001"],"learnings":[],"files":["src/auth.py","src/state.ts"],"state":"WAIT","summary":"Picked Zustand; awaiting confirmation"}
+```
+
+The agent uses this to answer "show me every entry that touched TASK-001" without reading the prose log.
+
+### Rollover
+
+When `log.md` exceeds `LOG_ACTIVE_ENTRIES + 5`:
+1. Move all but the most recent `LOG_ACTIVE_ENTRIES` into `log_archive/log_YYYY-MM.md`
+2. Add a one-line note at the top of `log.md`: `*Older entries: log_archive/*`
+3. `log_index.jsonl` is untouched (it always holds the full timeline)
+
+---
+
+## Context Budget (model-size adaptation)
+
+`LLM_init.md` declares the assumed context budget for the project:
+
+| Budget | Window | LOG_ACTIVE_ENTRIES |
+|--------|--------|--------------------|
+| `small` | 8k–32k tokens | 3 |
+| `medium` | 32k–128k tokens | 10 |
+| `large` | 128k+ tokens | 25 |
+
+The agent self-checks at session start: if its actual window is smaller than the declared budget, it downgrades to the smaller-budget rules and warns the human. This avoids needing runtime hardware-detection infrastructure — the human picks at project init, the agent verifies at session start.
+
+---
+
+## PHASE 0: INITIALIZATION
+
+*Run once per project. Skip to Phase 1 if `GECK/` folder exists.*
+
+### Step 0.1 — Prerequisites (Human)
+
+1. Create GitHub repository, clone locally
+2. Create `LLM_init.md` (manually or via GECK Generator) — include the `Context Budget` field
+3. Instruct agent: "Read LLM_init.md and initialize the GECK."
+
+### Step 0.2 — GECK Initialization (Agent)
+
+1. Create `GECK/` folder
+2. Copy `GECK_Inst.md` template into folder
+3. Create empty `decisions/` and `learnings/` subfolders
+4. Create empty `decisions.md` and `learnings.md` index files (with header only)
+5. Create `log_archive/` subfolder
+6. Create empty `log_index.jsonl`
+7. Create `env.md` with environment detection appropriate to the stack
+8. Create `tasks.md` with initial tasks derived from `LLM_init.md` (assigning TASK-001, TASK-002, …)
+9. Create `log.md` with Entry #0:
+   ```
+   ## Entry #0 — <ISO ts> — touched: (init)
+   - Did: GECK initialized
+   - Files: GECK/*
+   - State: WAIT
+   - Next: Await confirmation to begin work
+   ```
+10. Append the matching line to `log_index.jsonl`
+11. **Verify** all files exist and state: **"GECK v1.3 initialized. Awaiting confirmation to proceed."**
+
+---
+
+## PHASE 1: EXECUTION LOOP
+
+*Repeat until success criteria are met.*
+
+### Step 1.1 — Drift Check (mandatory, every session)
+
+Before reading the log, restate from `LLM_init.md`:
+
+1. Project Goal (one sentence)
+2. Active TASK-IDs (from `tasks.md`)
+3. Constraints
+
+Then declare:
+
+```
+Drift Detected: YES | NO
+If YES: describe discrepancy, set checkpoint to WAIT, stop.
+```
+
+### Step 1.2 — Orient
+
+1. Read `decisions.md` (the index) — drill into specific files only as needed
+2. Read `learnings.md` (the index) — drill in only as needed
+3. Read `tasks.md` (full)
+4. Read last `LOG_ACTIVE_ENTRIES` from `log.md`, OR query `log_index.jsonl` for entries touching active TASK-IDs (whichever is more relevant)
+
+### Step 1.3 — Plan (Standard/Heavy mode)
+
+State:
+1. What you will do this turn
+2. Files you expect to modify
+3. What success looks like
+4. Assumptions
+
+### Step 1.4 — Execute
+
+Do the work.
+
+### Step 1.5 — Update Working Memory
+
+In order:
+1. Update `tasks.md` — transition states, add discovered subtasks
+2. If a decision was made: create `decisions/DECISION-NNN-slug.md`, add line to `decisions.md`
+3. If a learning emerged: create `learnings/LEARNING-NNN-slug.md`, add line to `learnings.md`
+4. Append entry to `log.md`
+5. Append matching line to `log_index.jsonl`
+6. If `log.md` exceeds `LOG_ACTIVE_ENTRIES + 5`: roll oldest into `log_archive/log_YYYY-MM.md`
+
+### Step 1.6 — Commit
+
+```bash
+git add <specific files>
+git commit -m "<type>: <description>"
+```
+
+Commit types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`. Branch (`experiment/<name>`) for risky work.
+
+### Step 1.7 — Checkpoint
+
+Evaluate and state:
+
+- **CONTINUE** — work stable, proceed to next task
+- **WAIT** — need human input or hit a blocker (state what you need)
+- **ROLLBACK** — something broke, invoke Rollback Protocol
+
+---
+
+## PHASE 2: COMPLETION
+
+When SUCCESS CRITERIA from `LLM_init.md` are met:
+
+1. Final log entry summarizing build, known limits, suggested improvements
+2. All tasks `[x]` or moved to backlog with rationale
+3. State: **"SUCCESS CRITERIA MET. Ready for human review."**
+
+---
+
+## Work Modes
+
+| Mode | When | Required updates |
+|------|------|------------------|
+| **Light** | Single-file fix, typo, trivial chore | tasks.md only |
+| **Standard** | Feature work, multi-file changes | Plan + tasks.md + log.md + log_index.jsonl |
+| **Heavy** | Architecture changes, new subsystems | All of Standard + DECISION-NNN record |
+
+---
+
+## Protocols
+
+### Rollback Protocol
+
+1. Identify problem and affected commits
+2. Log entry documenting what broke and why
+3. Propose: `git revert <commit>` for clean cases, manual fix otherwise
+4. State: **"ROLLBACK NEEDED. Awaiting approval."**
+5. Wait for human confirmation
+
+### Decision Fork Protocol
+
+When facing a non-obvious choice:
+
+1. Identify the fork
+2. List 2–3 options with brief pros/cons
+3. State recommendation with reasoning
+4. Set checkpoint WAIT
+5. After human chooses: create `DECISION-NNN-slug.md`
+
+### Learning Capture Protocol
+
+When something breaks unexpectedly OR a non-obvious approach works:
+
+1. Create `LEARNING-NNN-slug.md` with **Rule**, **Why**, **How to apply**
+2. Add line to `learnings.md` index
+3. Reference `LEARNING-NNN` in the current log entry's `Refs` line
+
+This is the protocol's loss-prevention mechanism. Future sessions read learnings cheaply (the index alone) and avoid re-stepping on the same rakes.
+
+---
+
+## File Responsibilities
+
+| File | Read | Write | Rules |
+|------|------|-------|-------|
+| `LLM_init.md` | Always | Never | Human-owned; your north star |
+| `GECK_Inst.md` | Session start (or as needed) | Never | These instructions |
+| `tasks.md` | Every turn | Every turn | Forward-only state transitions |
+| `decisions.md` | Index every turn | When decision made | Append-only; supersede via `superseded-by` |
+| `decisions/*.md` | On demand | When decision made | One file per decision; never delete |
+| `learnings.md` | Index every turn | When learning emerges | Append-only |
+| `learnings/*.md` | On demand | When learning emerges | One file per learning; never delete |
+| `log.md` | Last N entries | Append every turn | Never edit past entries; rollover when full |
+| `log_index.jsonl` | Query as needed | Append every turn | One line per entry, ever |
+| `log_archive/*.md` | On demand | Auto-rollover | Append-only |
+| `env.md` | As needed | When env changes | Document, don't assume |
+
+---
+
+## Red Lines — Always Stop and Ask
+
+- Deleting files or data
+- Changing auth/security code
+- Modifying database schemas
+- Actions that cannot be undone
+- Uncertainty about what user wants
+- Significant architectural decisions (use Decision Fork Protocol)
+- Drift detected at session start
+
+---
+
+## Quick Reference
+
+### Starting a session
+1. Drift Check (restate goal + active TASK-IDs + constraints)
+2. Read `decisions.md` index, `learnings.md` index, `tasks.md`
+3. Read last N log entries OR query `log_index.jsonl`
+4. Pick next task and begin
+
+### Per turn
+1. Plan (Standard/Heavy)
+2. Execute
+3. Update tasks → decisions/learnings (if any) → log.md → log_index.jsonl
+4. Commit
+5. State checkpoint
+
+---
+
+## Changelog
+
+### v1.3 (Current)
+- **Folder rename:** `LLM_GECK/` → `GECK/` (the `LLM_` prefix was redundant)
+- **Memory model:** explicit episodic vs. semantic split
+- **Per-record files for decisions and learnings**, with index files (Claude Code memory style)
+- **`learnings.md` + `learnings/`** added — captures gotchas semantically
+- **`log_index.jsonl`** added — machine-readable history; agent queries instead of re-reading prose
+- **Tightened per-turn log entry** — narrative bloat moves to commit messages / PRs
+- **Tiered log:** active `log.md` holds last N entries, older roll to `log_archive/`
+- **Typed tasks:** `TASK-NNN | TYPE | SCOPE | OWNER` syntax with state machine
+- **Drift Check:** mandatory at session start
+- **Context Budget:** declared in `LLM_init.md`, drives `LOG_ACTIVE_ENTRIES`
+
+### v1.2
+- Added `GECK_Inst.md`
+- Added file specifications section
+- Added GECK_Inst.md template
+
+### v1.1
+- Consolidated duplicate templates
+- Work modes (Light/Standard/Heavy)
+- Standard markdown checkbox syntax
+- Log archival protocol
+
+### v1.0
+- Initial release

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool for generating macro-prompts, as well as a GitHub Repo framework, for use
 
 ## Contents
 
-- **GECK/** - The Garden of Eden Creation Kit protocol specifications (v1.0, v1.1, v1.2)
+- **GECK/** - The Garden of Eden Creation Kit protocol specifications (v1.0, v1.1, v1.2, v1.3)
 - **geck_generator/** - A GUI/CLI tool to generate GECK project files
 
 ---
@@ -23,19 +23,25 @@ When working with CLI LLM agents (Claude Code, Aider, Cursor, etc.):
 
 ### How GECK Works
 
-GECK (v1.2) creates a simple folder structure in your project:
+GECK (v1.3) creates a structured folder in your project:
 
 ```
 your_project/
 └── GECK/
-    ├── LLM_init.md      # Your project goals and constraints
-    ├── GECK_Inst.md     # Instructions for the AI agent
-    ├── log.md           # Session history (long-term memory)
-    ├── tasks.md         # Current task list (working memory)
-    └── env.md           # Environment documentation
+    ├── LLM_init.md         # Project goals, constraints, context budget
+    ├── GECK_Inst.md        # Instructions for the AI agent (protocol v1.3)
+    ├── env.md              # Environment documentation
+    ├── tasks.md            # Typed tasks with stable TASK-NNN IDs
+    ├── log.md              # Episodic per-turn log (tightened format)
+    ├── log_index.jsonl     # Machine-readable log index (one JSON line per entry)
+    ├── decisions.md        # Index of decision records
+    ├── decisions/          # Per-decision files (DECISION-NNN.md)
+    ├── learnings.md        # Index of learning records
+    ├── learnings/          # Per-learning files (LEARNING-NNN.md)
+    └── log_archive/        # Rolled-over log entries
 ```
 
-At the start of each session, you point the AI to these files. It reads the context, understands what was done before, and continues where it left off.
+At the start of each session, you point the AI to these files. It reads only the slice it needs (driven by the declared **Context Budget**), understands what was done before, and continues where it left off.
 
 ---
 
@@ -218,11 +224,22 @@ Read the last log entry and remind me where we left off.
 
 | Version | Status | Description |
 |---------|--------|-------------|
-| v1.2 | Current | Added GECK_Inst.md for AI agent instructions |
+| v1.3 | Current | Typed tasks (TASK-NNN), decisions/learnings as first-class records, Drift Check, tiered log + JSONL index, Context Budget |
+| v1.2 | Stable | Added GECK_Inst.md for AI agent instructions |
 | v1.1 | Stable | Work modes, simplified file names |
 | v1.0 | Legacy | Initial release |
 
-See `GECK/GECK_Macro_v1.2.md` for the full protocol specification.
+See `GECK/GECK_Macro_v1.3.md` for the full protocol specification.
+
+### Why v1.3
+
+v1.3 sharpens the protocol around how a fresh agent reconstructs context across sessions:
+
+- **Typed tasks with stable IDs.** Tasks are addressable as `TASK-NNN` with a TYPE/SCOPE/OWNER header, so log entries and decisions can reference them without ambiguity.
+- **Decisions and learnings are first-class.** Each is a per-record file under `decisions/` or `learnings/` with YAML frontmatter, indexed by `decisions.md` / `learnings.md` — the same composition pattern used by Claude Code's memory system, adapted clean-room for git.
+- **Tightened log + JSONL index.** `log.md` keeps the human-auditable narrative (Did / Files / State / Refs / Next); `log_index.jsonl` gives the next agent a one-line-per-entry index it can scan cheaply.
+- **Drift Check.** A short cognitive checksum at session start catches stale assumptions before they propagate.
+- **Context Budget.** A `small` / `medium` / `large` parameter declared in `LLM_init.md` tells the next agent how many recent log entries to load (3 / 10 / 25), so the protocol adapts to the model window without per-agent guessing.
 
 ---
 

--- a/geck_generator/__main__.py
+++ b/geck_generator/__main__.py
@@ -17,6 +17,7 @@ Examples:
   python -m geck_generator --cli              # Interactive CLI
   python -m geck_generator --gui              # GUI application
   python -m geck_generator --profile web_app -o ./project/LLM_init.md
+  python -m geck_generator --profile web_app --context-budget large -o ./LLM_init.md
   python -m geck_generator --cli --init-geck  # Create full GECK folder
   python -m geck_generator --list-profiles    # Show available profiles
 
@@ -96,6 +97,14 @@ Shortcut Management:
         type=str,
         metavar="TEXT",
         help="Project goal (for --profile mode)",
+    )
+
+    parser.add_argument(
+        "--context-budget",
+        choices=["small", "medium", "large"],
+        default=None,
+        metavar="BUDGET",
+        help="Assumed model context window (small/medium/large) — drives v1.3 LOG_ACTIVE_ENTRIES",
     )
 
     # Shortcut management arguments
@@ -254,6 +263,8 @@ Shortcut Management:
             "project_name": project_name,
             "goal": goal,
         }
+        if args.context_budget:
+            config["context_budget"] = args.context_budget
 
         content = generator.generate(config)
 

--- a/geck_generator/cli/interactive.py
+++ b/geck_generator/cli/interactive.py
@@ -270,6 +270,24 @@ def run_interactive() -> dict[str, Any]:
     if config["initial_task"] is None:
         config["initial_task"] = ""
 
+    # Step 7: Context budget (drives LOG_ACTIVE_ENTRIES in v1.3)
+    print("\n🧠 Step 7: Context Budget\n")
+    print("  Tells the agent how much of the log to keep active per session.")
+    print("  Pick the smallest tier that comfortably fits the model you intend to use.\n")
+
+    budget_choice = questionary.select(
+        "Context budget for the assumed model:",
+        choices=[
+            questionary.Choice("small  (8k–32k tokens, e.g. older models)", value="small"),
+            questionary.Choice("medium (32k–128k tokens, most current models)", value="medium"),
+            questionary.Choice("large  (128k+ tokens, frontier models)", value="large"),
+        ],
+        default="medium",
+        style=custom_style,
+    ).ask()
+
+    config["context_budget"] = budget_choice or "medium"
+
     # Preview
     print("\n" + "=" * 60)
     print("  Preview")

--- a/geck_generator/core/generator.py
+++ b/geck_generator/core/generator.py
@@ -94,6 +94,10 @@ class GECKGenerator:
     # Standard list of platforms for env.md
     ALL_PLATFORMS = ["Windows", "macOS", "Linux", "Docker", "iOS", "Android", "Web"]
 
+    # Context budget options for v1.3 (drives LOG_ACTIVE_ENTRIES)
+    CONTEXT_BUDGETS = ("small", "medium", "large")
+    DEFAULT_CONTEXT_BUDGET = "medium"
+
     def __init__(self):
         """Initialize the generator with template engine and profile manager."""
         self.template_engine = TemplateEngine()
@@ -119,6 +123,7 @@ class GECKGenerator:
         config.setdefault("success_criteria", [])
         config.setdefault("frameworks", [])
         config.setdefault("platforms", [])
+        config.setdefault("context_budget", self.DEFAULT_CONTEXT_BUDGET)
 
         # Render the template
         return self.template_engine.render("llm_init", config)
@@ -214,7 +219,7 @@ class GECKGenerator:
 
     def init_geck_folder(self, project_path: Path | str, config: dict[str, Any]) -> Path:
         """
-        Create full GECK folder structure with all files.
+        Create full GECK v1.3 folder structure with all files and subfolders.
 
         Creates:
         - GECK/LLM_init.md
@@ -222,6 +227,12 @@ class GECKGenerator:
         - GECK/env.md
         - GECK/tasks.md
         - GECK/log.md
+        - GECK/log_index.jsonl
+        - GECK/log_archive/
+        - GECK/decisions.md
+        - GECK/decisions/
+        - GECK/learnings.md
+        - GECK/learnings/
 
         Args:
             project_path: Path to the project root
@@ -233,8 +244,11 @@ class GECKGenerator:
         project_path = Path(project_path)
         geck_folder = project_path / "GECK"
 
-        # Create the GECK folder
+        # Create the GECK folder + subfolders
         geck_folder.mkdir(parents=True, exist_ok=True)
+        (geck_folder / "decisions").mkdir(exist_ok=True)
+        (geck_folder / "learnings").mkdir(exist_ok=True)
+        (geck_folder / "log_archive").mkdir(exist_ok=True)
 
         # Apply profile if specified
         if "profile" in config and config["profile"]:
@@ -246,14 +260,15 @@ class GECKGenerator:
         config.setdefault("success_criteria", [])
         config.setdefault("frameworks", [])
         config.setdefault("platforms", [])
+        config.setdefault("context_budget", self.DEFAULT_CONTEXT_BUDGET)
 
         # Detect environment
         env_info = _detect_environment()
         timestamp = env_info["timestamp"]
+        iso_timestamp = datetime.now().isoformat(timespec="seconds")
 
-        # Derive initial tasks and understood goals
+        # Derive initial tasks
         initial_tasks = self._derive_initial_tasks(config)
-        understood_goals = self._parse_goal_to_bullets(config.get("goal", ""))
 
         # 1. Write LLM_init.md inside GECK folder
         init_content = self.template_engine.render("llm_init", config)
@@ -276,7 +291,7 @@ class GECKGenerator:
         env_content = self.template_engine.render("env", env_vars)
         (geck_folder / "env.md").write_text(env_content, encoding="utf-8")
 
-        # 4. Write tasks.md (with initial tasks)
+        # 4. Write tasks.md (typed v1.3 tasks)
         tasks_vars = {
             "project_name": config["project_name"],
             "timestamp": timestamp,
@@ -285,15 +300,31 @@ class GECKGenerator:
         tasks_content = self.template_engine.render("tasks", tasks_vars)
         (geck_folder / "tasks.md").write_text(tasks_content, encoding="utf-8")
 
-        # 5. Write log.md (Entry #0 format)
+        # 5. Write log.md (tightened Entry #0)
         log_vars = {
             "project_name": config["project_name"],
             "timestamp": timestamp,
-            "understood_goals": understood_goals,
-            "initial_tasks": initial_tasks,
         }
         log_content = self.template_engine.render("log", log_vars)
         (geck_folder / "log.md").write_text(log_content, encoding="utf-8")
+
+        # 6. Write log_index.jsonl (Entry #0 line)
+        log_index_content = self.template_engine.render(
+            "log_index", {"timestamp": iso_timestamp}
+        )
+        (geck_folder / "log_index.jsonl").write_text(log_index_content, encoding="utf-8")
+
+        # 7. Write decisions.md index (empty)
+        decisions_content = self.template_engine.render(
+            "decisions_index", {"project_name": config["project_name"]}
+        )
+        (geck_folder / "decisions.md").write_text(decisions_content, encoding="utf-8")
+
+        # 8. Write learnings.md index (empty)
+        learnings_content = self.template_engine.render(
+            "learnings_index", {"project_name": config["project_name"]}
+        )
+        (geck_folder / "learnings.md").write_text(learnings_content, encoding="utf-8")
 
         return geck_folder
 
@@ -398,6 +429,14 @@ class GECKGenerator:
             if not isinstance(config["platforms"], list):
                 errors.append("Platforms must be a list")
 
+        # Validate context_budget is one of the allowed values
+        if "context_budget" in config and config["context_budget"]:
+            if config["context_budget"] not in self.CONTEXT_BUDGETS:
+                errors.append(
+                    f"context_budget must be one of {self.CONTEXT_BUDGETS}, "
+                    f"got {config['context_budget']!r}"
+                )
+
         return errors
 
     def get_config_template(self) -> dict[str, Any]:
@@ -422,6 +461,7 @@ class GECKGenerator:
             "context": "",
             "initial_task": "",
             "git_branch": None,
+            "context_budget": self.DEFAULT_CONTEXT_BUDGET,
         }
 
     def generate_repor_instructions(

--- a/geck_generator/core/templates.py
+++ b/geck_generator/core/templates.py
@@ -1,4 +1,4 @@
-"""Template definitions and rendering for GECK Generator."""
+"""Template definitions and rendering for GECK Generator (v1.3)."""
 
 from datetime import datetime
 from typing import Any
@@ -14,6 +14,8 @@ LLM_INIT_TEMPLATE = """\
 **Local Path:** {{ local_path | default('Not specified', true) }}
 {% if git_branch %}**Branch:** {{ git_branch }}
 {% endif %}**Created:** {{ created_date }}
+**GECK Protocol:** v1.3
+**Context Budget:** {{ context_budget | default('medium', true) }}
 
 ## Goal
 
@@ -42,27 +44,64 @@ LLM_INIT_TEMPLATE = """\
 {{ initial_task | default('Begin implementation based on the goal and success criteria above.', true) }}
 """
 
-# GECK_Inst.md template (static - AI agent instructions from v1.2 spec)
+# GECK_Inst.md template (v1.3 — agent operating instructions)
 GECK_INST_TEMPLATE = """\
 # GECK Agent Instructions
 ## Quick Reference for AI Assistants
 
-**Protocol Version:** 1.2
+**Protocol Version:** 1.3
 
 ---
 
 ## On Session Start
 
-1. **Check for GECK folder:** Does `GECK/` exist?
-   - NO → Run Phase 0 initialization
-   - YES → Continue to step 2
+1. **Check for `GECK/` folder:** if missing → run Phase 0 initialization, otherwise continue.
 
-2. **Load context:**
-   - Read `LLM_init.md` for goals and constraints
-   - Read last entry in `GECK/log.md`
-   - Read `GECK/tasks.md` for current work
+2. **Drift Check (mandatory).** Before reading the log, restate from `LLM_init.md`:
+   - Project Goal (one sentence)
+   - Active TASK-IDs (from `tasks.md`)
+   - Constraints
+   Then declare: `Drift Detected: YES | NO`. If YES, set checkpoint to WAIT and stop.
 
-3. **Identify next action** from tasks.md or human instruction
+3. **Context budget self-check.** `LLM_init.md` declares the assumed budget (small/medium/large).
+   If your actual context window is smaller than declared, downgrade to the smaller-budget rules
+   and warn the human.
+
+4. **Load context (in this order):**
+   - `decisions.md` — read the index; drill into individual `decisions/*.md` files only as needed
+   - `learnings.md` — read the index; drill into individual `learnings/*.md` files only as needed
+   - `tasks.md` — full
+   - `log.md` — last N entries (N from context budget) OR query `log_index.jsonl`
+     for entries touching active TASK-IDs
+
+---
+
+## Memory Model
+
+| Layer | File(s) | Purpose |
+|-------|---------|---------|
+| Goals | `LLM_init.md` | North star; never modify |
+| Working memory | `tasks.md` | What to do now (typed, state-machined) |
+| Semantic — decisions | `decisions.md` + `decisions/` | Why we chose what we chose |
+| Semantic — learnings | `learnings.md` + `learnings/` | What broke before; what works |
+| Episodic | `log.md` (active) | Narrative continuity |
+| Episodic archive | `log_index.jsonl`, `log_archive/` | Full history; query, don't re-read |
+| Environment | `env.md` | Compatibility constraints |
+
+You do **not** re-read the full log every session. The index is your random-access layer.
+
+---
+
+## Context Budget → LOG_ACTIVE_ENTRIES
+
+| Budget | Window | Active log entries |
+|--------|--------|-------------------|
+| `small` | 8k–32k | 3 |
+| `medium` | 32k–128k | 10 |
+| `large` | 128k+ | 25 |
+
+When `log.md` exceeds `LOG_ACTIVE_ENTRIES + 5`, roll the oldest entries into
+`log_archive/log_YYYY-MM.md`. `log_index.jsonl` always holds the full timeline.
 
 ---
 
@@ -72,40 +111,117 @@ GECK_INST_TEMPLATE = """\
 |------|------|-------|-------|
 | `LLM_init.md` | Always | Never | Human-owned, your north star |
 | `GECK_Inst.md` | Session start | Never | These instructions |
-| `log.md` | Last entry | Append only | Never edit past entries |
-| `tasks.md` | Every turn | Update freely | Keep current |
+| `tasks.md` | Every turn | Every turn | Forward-only state transitions |
+| `decisions.md` | Index every turn | When decision made | Append-only |
+| `decisions/*.md` | On demand | When decision made | One file per decision; never delete |
+| `learnings.md` | Index every turn | When learning emerges | Append-only |
+| `learnings/*.md` | On demand | When learning emerges | One file per learning; never delete |
+| `log.md` | Last N entries | Append every turn | Never edit past entries |
+| `log_index.jsonl` | Query as needed | Append every turn | One JSON object per line |
+| `log_archive/*.md` | On demand | Auto-rollover | Append-only |
 | `env.md` | As needed | When env changes | Document, don't assume |
 
 ---
 
-## Work Mode Selection
+## Tasks
 
-**Before starting work, select mode:**
+Format:
+```
+- [<state>] TASK-NNN | TYPE: <type> | SCOPE: <scope> | OWNER: <owner>
+  - Description (nested bullets give the tree shape natively)
+```
 
-- **Light mode** (single file, minor fix):
-  - Just do it
-  - Update tasks.md
-  - No log entry needed
+States: `[ ]` proposed/accepted, `[~]` active, `[!:reason]` blocked, `[x]` completed.
+State transitions are forward-only (or to blocked). Completed tasks are immutable;
+file a new task instead of reopening.
 
-- **Standard mode** (feature, multi-file):
-  - State plan first
-  - Do work
-  - Update tasks.md
-  - Add log entry
+TYPE: `feature | fix | refactor | research | chore | docs | test`
+SCOPE: `small | medium | large`
+OWNER: `agent | human`
 
-- **Heavy mode** (architecture, risky):
-  - State plan first
-  - Consider branching
-  - Do work
-  - Update tasks.md
-  - Add detailed log entry
-  - May require WAIT checkpoint
+Log entries MUST cite the TASK-IDs they touched. Completing a task MUST cite the log entry.
+
+---
+
+## Decisions
+
+Made a real decision? Create `decisions/DECISION-NNN-<slug>.md` with frontmatter:
+
+```yaml
+---
+id: DECISION-NNN
+title: <short title>
+date: <ISO timestamp>
+status: active
+related-tasks: [TASK-NNN]
+related-decisions: []
+superseded-by: null
+---
+```
+
+Body: lead with the decision, then **Why:** and **Consequences:**.
+
+Append a one-line entry to `decisions.md`. Reference the DECISION-ID in the current log entry.
+Heavy mode MUST log a DECISION-ID.
+
+---
+
+## Learnings
+
+Something broke? A non-obvious approach worked? Create `learnings/LEARNING-NNN-<slug>.md`:
+
+```yaml
+---
+id: LEARNING-NNN
+title: <short title>
+date: <ISO timestamp>
+related-tasks: [TASK-NNN]
+---
+```
+
+Body: lead with the **Rule**, then **Why:** (what broke / what was tried)
+and **How to apply:** (when this kicks in).
+
+Append a one-line entry to `learnings.md`. Reference the LEARNING-ID in the current log entry.
+
+This is the protocol's loss-prevention mechanism — future sessions read the index alone
+and avoid re-stepping on the same rakes.
+
+---
+
+## Per-Turn Log Entry (tightened)
+
+```
+## Entry #N — <ISO timestamp> — touched: TASK-001, TASK-004
+- Did: <one line>
+- Files: <comma-separated paths>
+- State: CONTINUE | WAIT | ROLLBACK
+- Refs: DECISION-002, LEARNING-001    (omit line if none)
+- Next: <one line>
+```
+
+Then append the matching JSON line to `log_index.jsonl`:
+
+```json
+{"id":N,"ts":"...","tasks":["TASK-001"],"decisions":[],"learnings":[],"files":[],"state":"CONTINUE","summary":"..."}
+```
+
+Long-form context (rationale, code snippets, screenshots) belongs in commit messages
+and PR descriptions, not duplicated in the log.
+
+---
+
+## Work Modes
+
+| Mode | When | Required updates |
+|------|------|------------------|
+| **Light** | Single-file fix, typo, trivial chore | tasks.md only |
+| **Standard** | Feature work, multi-file changes | tasks + log + log_index |
+| **Heavy** | Architecture changes, new subsystems | All of Standard + DECISION-NNN |
 
 ---
 
 ## Checkpoint Rules
-
-After each work cycle, evaluate:
 
 | Situation | Checkpoint | Action |
 |-----------|------------|--------|
@@ -114,15 +230,16 @@ After each work cycle, evaluate:
 | Unclear requirements | WAIT | Ask for clarification |
 | Something broke | ROLLBACK | Document, propose fix, stop |
 | Multiple valid approaches | WAIT | Present options, recommend one |
+| Drift detected at session start | WAIT | Describe discrepancy, stop |
 
 ---
 
 ## Commit Rules
 
 - Commit after each successful work cycle
-- Use semantic commit messages: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
+- Semantic messages: `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`
 - Stage specific files, not `git add .`
-- Branch for experimental work
+- Branch (`experiment/<name>`) for risky work
 
 ---
 
@@ -133,33 +250,21 @@ After each work cycle, evaluate:
 - Modifying database schemas
 - Actions that cannot be undone
 - Uncertainty about what user wants
-- Significant architectural decisions
-
----
-
-## Log Entry Format
-
-When logging (Standard/Heavy mode), include:
-
-1. **Summary** — What you did (1-2 sentences)
-2. **Actions** — Bullet list of specific actions
-3. **Files Changed** — Path and brief description
-4. **Commits** — Hash and message
-5. **Findings** — Anything notable (or "None")
-6. **Issues** — Problems with severity (or "None")
-7. **Checkpoint** — CONTINUE / WAIT / ROLLBACK
-8. **Next** — What comes next
+- Significant architectural decisions (use Decision Fork Protocol)
+- Drift detected at session start
 
 ---
 
 ## Common Mistakes to Avoid
 
-1. **Don't edit log.md history** — Append only
-2. **Don't assume environment** — Check env.md or detect
-3. **Don't skip task updates** — tasks.md is your working memory
-4. **Don't make big decisions alone** — Use Decision Fork Protocol
-5. **Don't commit without testing** — Verify work before commit
-6. **Don't forget to state checkpoint** — Human needs to know status
+1. **Don't re-read the full log every session** — query `log_index.jsonl` instead
+2. **Don't edit past log entries or completed tasks** — append-only / forward-only
+3. **Don't bury decisions in log prose** — promote to `decisions/DECISION-NNN.md`
+4. **Don't bury learnings in log prose** — promote to `learnings/LEARNING-NNN.md`
+5. **Don't skip the Drift Check** — it's the cognitive checksum that prevents goal mutation
+6. **Don't skip the index update** — `log_index.jsonl` is how future sessions navigate
+7. **Don't make big decisions alone** — use Decision Fork Protocol
+8. **Don't forget to state checkpoint** — human needs to know status
 """
 
 # env.md template
@@ -199,7 +304,7 @@ ENV_TEMPLATE = """\
 {% endfor %}
 """
 
-# tasks.md template
+# tasks.md template (v1.3 — typed, state-machined)
 TASKS_TEMPLATE = """\
 # Tasks — {{ project_name }}
 
@@ -207,19 +312,24 @@ TASKS_TEMPLATE = """\
 
 ## Legend
 
-- `[ ]` — Not started
-- `[x]` — Complete
-- `[BLOCKED: reason]` — Cannot proceed
-- `[DECISION: topic]` — Awaiting human input
+- `[ ]` proposed/accepted (not started)
+- `[~]` active (in progress)
+- `[!:reason]` blocked (reason required)
+- `[x]` completed (immutable; cite log entry)
+
+State transitions are forward-only (or to blocked). Completed tasks are not re-opened —
+file a new task instead.
 
 ## Current Sprint
 
 {% if initial_tasks %}
 {% for task in initial_tasks %}
-- [ ] {{ task }}
+- [ ] TASK-{{ '%03d' % (loop.index) }} | TYPE: feature | SCOPE: medium | OWNER: agent
+  - {{ task }}
 {% endfor %}
 {% else %}
-- [ ] Review project goals and begin implementation
+- [ ] TASK-001 | TYPE: feature | SCOPE: medium | OWNER: agent
+  - Review project goals and begin implementation
 {% endif %}
 
 ## Backlog
@@ -231,36 +341,45 @@ TASKS_TEMPLATE = """\
 (empty)
 """
 
-# log.md template
+# log.md template (v1.3 — tightened per-turn entries)
 LOG_TEMPLATE = """\
 # Session Log — {{ project_name }}
 
-*Append only. Do not edit existing entries.*
+*Append only. Older entries roll into `log_archive/` once the active log exceeds the
+context budget. Full history queryable via `log_index.jsonl`.*
 
 ---
 
-## Entry #0 — {{ timestamp }}
+## Entry #0 — {{ timestamp }} — touched: (init)
+- Did: GECK v1.3 initialized
+- Files: GECK/*
+- State: WAIT
+- Next: Await human confirmation to begin work
+"""
 
-### Summary
-Project initialized. GECK structure created.
+# log_index.jsonl template — Entry #0 line, machine-readable
+LOG_INDEX_TEMPLATE = """\
+{"id":0,"ts":"{{ timestamp }}","tasks":[],"decisions":[],"learnings":[],"files":["GECK/*"],"state":"WAIT","summary":"GECK v1.3 initialized"}
+"""
 
-### Understood Goals
-{% for goal_item in understood_goals %}
-- {{ goal_item }}
-{% endfor %}
+# decisions.md index template
+DECISIONS_INDEX_TEMPLATE = """\
+# Decisions — {{ project_name }}
 
-### Questions/Ambiguities
-None
+*One line per decision record. Drill into the file for rationale.*
+*Append-only. Mark superseded decisions with `(superseded by DECISION-NNN)` instead of deleting.*
 
-### Initial Tasks
-{% for task in initial_tasks %}
-- {{ task }}
-{% endfor %}
+(no decisions yet)
+"""
 
-### Checkpoint
-**Status:** WAIT — Awaiting confirmation to begin work.
+# learnings.md index template
+LEARNINGS_INDEX_TEMPLATE = """\
+# Learnings — {{ project_name }}
 
----
+*One line per learning record. Drill into the file for context.*
+*Append-only. Future sessions read this index to avoid re-stepping on the same rakes.*
+
+(no learnings yet)
 """
 
 # GECK Repor agent instructions template
@@ -366,6 +485,9 @@ class TemplateEngine:
         "env": ENV_TEMPLATE,
         "tasks": TASKS_TEMPLATE,
         "log": LOG_TEMPLATE,
+        "log_index": LOG_INDEX_TEMPLATE,
+        "decisions_index": DECISIONS_INDEX_TEMPLATE,
+        "learnings_index": LEARNINGS_INDEX_TEMPLATE,
         "repor": REPOR_TEMPLATE,
     }
 

--- a/geck_generator/gui/app.py
+++ b/geck_generator/gui/app.py
@@ -690,6 +690,32 @@ class GECKGeneratorGUI:
         self.initial_task_text = scrolledtext.ScrolledText(task_frame, height=2, wrap=tk.WORD)
         self.initial_task_text.pack(fill=tk.X, expand=True, pady=5)
 
+        # Context Budget (v1.3) — drives LOG_ACTIVE_ENTRIES at runtime
+        budget_frame = ttk.LabelFrame(self.goals_frame, text="Context Budget (v1.3)", padding=10)
+        budget_frame.pack(fill=tk.X, pady=5)
+
+        ttk.Label(
+            budget_frame,
+            text="Assumed model context window. Drives how many log entries the agent keeps active.",
+            foreground="gray",
+            wraplength=500,
+        ).pack(anchor=tk.W)
+
+        self.context_budget_var = tk.StringVar(value="medium")
+        budget_row = ttk.Frame(budget_frame)
+        budget_row.pack(anchor=tk.W, pady=(5, 0))
+        for label, value in (
+            ("small (8k–32k)", "small"),
+            ("medium (32k–128k)", "medium"),
+            ("large (128k+)", "large"),
+        ):
+            ttk.Radiobutton(
+                budget_row,
+                text=label,
+                variable=self.context_budget_var,
+                value=value,
+            ).pack(side=tk.LEFT, padx=(0, 12))
+
         # Info about default task
         default_task_info = ttk.Label(
             task_frame,
@@ -875,6 +901,7 @@ class GECKGeneratorGUI:
                 p for p, var in self.platforms_vars.items() if var.get()
             ],
             "git_branch": get_current_branch(self.local_path_var.get()) if self.boot_is_git_repo else None,
+            "context_budget": self.context_budget_var.get(),
         }
         return config
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -362,3 +362,124 @@ class TestGECKGeneratorHelperMethods:
         """_parse_goal_to_bullets should handle empty goal."""
         bullets = generator._parse_goal_to_bullets("")
         assert bullets == ["No goal specified"]
+
+
+class TestGECKv13Features:
+    """Tests for GECK v1.3 additions: typed tasks, decisions, learnings, log index, context budget."""
+
+    def test_default_context_budget_is_medium(self, generator):
+        """DEFAULT_CONTEXT_BUDGET should be 'medium'."""
+        assert generator.DEFAULT_CONTEXT_BUDGET == "medium"
+
+    def test_context_budgets_set(self, generator):
+        """CONTEXT_BUDGETS should expose the three valid tiers."""
+        assert set(generator.CONTEXT_BUDGETS) == {"small", "medium", "large"}
+
+    def test_get_config_template_includes_context_budget(self, generator):
+        """Config template should include context_budget defaulting to medium."""
+        template = generator.get_config_template()
+        assert template.get("context_budget") == "medium"
+
+    def test_validate_config_accepts_valid_context_budget(self, generator, sample_config):
+        """validate_config should accept any of small/medium/large."""
+        for budget in ("small", "medium", "large"):
+            cfg = sample_config.copy()
+            cfg["context_budget"] = budget
+            assert generator.validate_config(cfg) == []
+
+    def test_validate_config_rejects_invalid_context_budget(self, generator, sample_config):
+        """validate_config should reject context_budget outside the allowed set."""
+        cfg = sample_config.copy()
+        cfg["context_budget"] = "huge"
+        errors = generator.validate_config(cfg)
+        assert any("context_budget" in e for e in errors)
+
+    def test_generate_includes_context_budget_field(self, generator, sample_config):
+        """Generated LLM_init.md should expose Context Budget."""
+        cfg = sample_config.copy()
+        cfg["context_budget"] = "large"
+        result = generator.generate(cfg)
+        assert "Context Budget" in result
+        assert "large" in result
+
+    def test_generate_defaults_context_budget_when_missing(self, generator, minimal_config):
+        """Missing context_budget should fall back to medium in output."""
+        result = generator.generate(minimal_config)
+        assert "Context Budget" in result
+        assert "medium" in result
+
+    def test_generate_includes_protocol_version(self, generator, sample_config):
+        """Generated LLM_init.md should declare GECK Protocol v1.3."""
+        result = generator.generate(sample_config)
+        assert "GECK Protocol" in result
+        assert "v1.3" in result
+
+    def test_init_geck_folder_creates_decisions_subfolder(self, generator, sample_config, temp_dir):
+        """init_geck_folder should create decisions/ subfolder."""
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+        assert (geck_path / "decisions").is_dir()
+
+    def test_init_geck_folder_creates_learnings_subfolder(self, generator, sample_config, temp_dir):
+        """init_geck_folder should create learnings/ subfolder."""
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+        assert (geck_path / "learnings").is_dir()
+
+    def test_init_geck_folder_creates_log_archive_subfolder(self, generator, sample_config, temp_dir):
+        """init_geck_folder should create log_archive/ subfolder."""
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+        assert (geck_path / "log_archive").is_dir()
+
+    def test_init_geck_folder_creates_decisions_index(self, generator, sample_config, temp_dir):
+        """init_geck_folder should create decisions.md index file."""
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+        decisions = geck_path / "decisions.md"
+        assert decisions.exists()
+        content = decisions.read_text(encoding="utf-8")
+        assert "Decisions" in content
+        assert sample_config["project_name"] in content
+
+    def test_init_geck_folder_creates_learnings_index(self, generator, sample_config, temp_dir):
+        """init_geck_folder should create learnings.md index file."""
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+        learnings = geck_path / "learnings.md"
+        assert learnings.exists()
+        content = learnings.read_text(encoding="utf-8")
+        assert "Learnings" in content
+        assert sample_config["project_name"] in content
+
+    def test_init_geck_folder_creates_log_index_jsonl(self, generator, sample_config, temp_dir):
+        """init_geck_folder should create log_index.jsonl with Entry #0 line."""
+        import json
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+        log_index = geck_path / "log_index.jsonl"
+        assert log_index.exists()
+        first_line = log_index.read_text(encoding="utf-8").strip().splitlines()[0]
+        record = json.loads(first_line)
+        assert record["id"] == 0
+        assert record["state"] == "WAIT"
+
+    def test_init_geck_folder_tasks_uses_typed_format(self, generator, sample_config, temp_dir):
+        """tasks.md should use the TASK-NNN | TYPE | SCOPE | OWNER format."""
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+        tasks_content = (geck_path / "tasks.md").read_text(encoding="utf-8")
+        assert "TASK-001" in tasks_content
+        assert "TYPE:" in tasks_content
+        assert "SCOPE:" in tasks_content
+        assert "OWNER:" in tasks_content
+
+    def test_init_geck_folder_geck_inst_is_v13(self, generator, sample_config, temp_dir):
+        """GECK_Inst.md should declare v1.3 and reference drift check + log_index."""
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+        inst = (geck_path / "GECK_Inst.md").read_text(encoding="utf-8")
+        assert "1.3" in inst
+        assert "Drift Check" in inst
+        assert "log_index.jsonl" in inst
+
+    def test_init_geck_folder_log_uses_tightened_entry(self, generator, sample_config, temp_dir):
+        """log.md Entry #0 should use the tightened v1.3 line format."""
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+        log_content = (geck_path / "log.md").read_text(encoding="utf-8")
+        assert "Entry #0" in log_content
+        assert "- Did:" in log_content
+        assert "- State: WAIT" in log_content
+        assert "- Next:" in log_content

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -193,6 +193,26 @@ class TestGECKFolderCreation:
         # web_app profile suggests criteria about state management and user interactions
         assert "State management" in llm_init or "User interactions" in llm_init
 
+    def test_geck_folder_creates_v13_artifacts(self, generator, sample_config, temp_dir):
+        """v1.3 init should create decisions/, learnings/, log_archive/, indexes, log_index.jsonl."""
+        geck_path = generator.init_geck_folder(temp_dir, sample_config)
+
+        # Subfolders
+        assert (geck_path / "decisions").is_dir()
+        assert (geck_path / "learnings").is_dir()
+        assert (geck_path / "log_archive").is_dir()
+
+        # Index files
+        assert (geck_path / "decisions.md").exists()
+        assert (geck_path / "learnings.md").exists()
+        assert (geck_path / "log_index.jsonl").exists()
+
+        # log_index.jsonl is parseable JSONL
+        import json
+        line = (geck_path / "log_index.jsonl").read_text(encoding="utf-8").strip().splitlines()[0]
+        record = json.loads(line)
+        assert record["id"] == 0
+
 
 class TestReporIntegration:
     """Integration tests for GECK Repor feature."""

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -10,6 +10,9 @@ from geck_generator.core.templates import (
     ENV_TEMPLATE,
     TASKS_TEMPLATE,
     LOG_TEMPLATE,
+    LOG_INDEX_TEMPLATE,
+    DECISIONS_INDEX_TEMPLATE,
+    LEARNINGS_INDEX_TEMPLATE,
     REPOR_TEMPLATE,
 )
 
@@ -29,6 +32,9 @@ class TestTemplateEngine:
         assert "env" in templates
         assert "tasks" in templates
         assert "log" in templates
+        assert "log_index" in templates
+        assert "decisions_index" in templates
+        assert "learnings_index" in templates
         assert "repor" in templates
 
     def test_render_llm_init_template(self, template_engine):
@@ -84,7 +90,7 @@ class TestTemplateEngine:
         assert "3.11.0" in result
 
     def test_render_tasks_template(self, template_engine):
-        """render should produce valid tasks.md content."""
+        """render should produce v1.3 typed tasks.md content."""
         variables = {
             "project_name": "Test",
             "timestamp": "2024-01-01 12:00:00",
@@ -93,22 +99,48 @@ class TestTemplateEngine:
         result = template_engine.render("tasks", variables)
 
         assert "Tasks" in result
-        assert "- [ ] Task 1" in result
-        assert "- [ ] Task 2" in result
+        # v1.3 wraps each task in a TASK-NNN line; description lives on a nested bullet
+        assert "TASK-001" in result
+        assert "TASK-002" in result
+        assert "TYPE: feature" in result
+        assert "Task 1" in result
+        assert "Task 2" in result
 
     def test_render_log_template(self, template_engine):
-        """render should produce valid log.md content."""
+        """render should produce v1.3 tightened log.md content."""
         variables = {
             "project_name": "Test",
             "timestamp": "2024-01-01 12:00:00",
-            "understood_goals": ["Goal 1", "Goal 2"],
-            "initial_tasks": ["Task 1"],
         }
         result = template_engine.render("log", variables)
 
         assert "Session Log" in result
         assert "Entry #0" in result
-        assert "Goal 1" in result
+        assert "- Did:" in result
+        assert "- State: WAIT" in result
+        assert "- Next:" in result
+
+    def test_render_log_index_template(self, template_engine):
+        """render should produce a single JSONL line for Entry #0."""
+        import json
+        result = template_engine.render("log_index", {"timestamp": "2026-04-17T14:00:00"})
+        line = result.strip().splitlines()[0]
+        record = json.loads(line)
+        assert record["id"] == 0
+        assert record["state"] == "WAIT"
+        assert record["ts"] == "2026-04-17T14:00:00"
+
+    def test_render_decisions_index_template(self, template_engine):
+        """decisions_index template should render with project name."""
+        result = template_engine.render("decisions_index", {"project_name": "Test"})
+        assert "Decisions — Test" in result
+        assert "no decisions yet" in result.lower()
+
+    def test_render_learnings_index_template(self, template_engine):
+        """learnings_index template should render with project name."""
+        result = template_engine.render("learnings_index", {"project_name": "Test"})
+        assert "Learnings — Test" in result
+        assert "no learnings yet" in result.lower()
 
     def test_render_repor_template(self, template_engine):
         """render should produce valid repor instructions."""
@@ -200,10 +232,41 @@ class TestTemplateConstants:
         assert "Backlog" in TASKS_TEMPLATE
 
     def test_log_template_has_required_sections(self):
-        """LOG_TEMPLATE should have required sections."""
+        """LOG_TEMPLATE should have required v1.3 entry fields."""
         assert "Session Log" in LOG_TEMPLATE
         assert "Entry #0" in LOG_TEMPLATE
-        assert "Checkpoint" in LOG_TEMPLATE
+        assert "- Did:" in LOG_TEMPLATE
+        assert "- State:" in LOG_TEMPLATE
+        assert "- Next:" in LOG_TEMPLATE
+
+    def test_log_index_template_is_jsonl(self):
+        """LOG_INDEX_TEMPLATE should be a single JSON object on one line."""
+        import json
+        # The template uses jinja {{ timestamp }}; substitute and parse.
+        rendered = LOG_INDEX_TEMPLATE.replace("{{ timestamp }}", "2026-04-17T00:00:00")
+        line = rendered.strip().splitlines()[0]
+        record = json.loads(line)
+        assert "id" in record and "tasks" in record and "decisions" in record
+
+    def test_decisions_index_template_has_header(self):
+        """DECISIONS_INDEX_TEMPLATE should include the heading and instructions."""
+        assert "Decisions —" in DECISIONS_INDEX_TEMPLATE
+        assert "Append-only" in DECISIONS_INDEX_TEMPLATE
+
+    def test_learnings_index_template_has_header(self):
+        """LEARNINGS_INDEX_TEMPLATE should include the heading and instructions."""
+        assert "Learnings —" in LEARNINGS_INDEX_TEMPLATE
+        assert "Append-only" in LEARNINGS_INDEX_TEMPLATE
+
+    def test_geck_inst_template_declares_v13(self):
+        """GECK_INST_TEMPLATE should declare protocol v1.3."""
+        assert "1.3" in GECK_INST_TEMPLATE
+        assert "Drift Check" in GECK_INST_TEMPLATE
+        assert "log_index.jsonl" in GECK_INST_TEMPLATE
+
+    def test_llm_init_template_includes_context_budget(self):
+        """LLM_INIT_TEMPLATE should expose the Context Budget field."""
+        assert "Context Budget" in LLM_INIT_TEMPLATE
 
     def test_repor_template_has_required_sections(self):
         """REPOR_TEMPLATE should have required sections."""


### PR DESCRIPTION
## Summary

GECK v1.3 sharpens cross-session context reconstruction for fresh agents. The folder is renamed `LLM_GECK/` → `GECK/` and gains typed addressable artifacts, first-class decision/learning records, a tightened log paired with a JSONL index, a Drift Check at session start, and a declared Context Budget that drives how much log history the next agent loads.

- **Protocol spec:** `GECK/GECK_Macro_v1.3.md` (new) — full v1.3 specification, memory-model table, file responsibilities, work modes, drift-check, context-budget table.
- **Templates:** `GECK_Inst.md`, `tasks.md`, `log.md` rewritten for v1.3; new `log_index.jsonl`, `decisions.md`, `learnings.md` indexes; `LLM_init.md` exposes `Context Budget`.
- **Generator:** `init_geck_folder()` now scaffolds `decisions/`, `learnings/`, `log_archive/` subfolders plus the JSONL index. `--context-budget {small,medium,large}` flag wired through CLI / interactive prompt / GUI radiobuttons.
- **Tests:** New `TestGECKv13Features` plus updates to template + integration tests cover the new artifacts, validation, and protocol-version declarations.
- **README:** v1.3 row in protocol-versions table, updated folder diagram, "Why v1.3" section.

## Test plan

- [ ] `pytest tests/` passes locally (could not run in this environment — no Python deps installed)
- [ ] `python -m geck_generator --list-templates` includes `log_index`, `decisions_index`, `learnings_index`
- [ ] `python -m geck_generator --cli --init-geck` produces a `GECK/` folder containing `decisions/`, `learnings/`, `log_archive/`, `log_index.jsonl`, `decisions.md`, `learnings.md`
- [ ] `python -m geck_generator --profile cli_tool --context-budget large --project-name X --goal Y` emits `**Context Budget:** large` in stdout
- [ ] GUI Goals tab shows the Context Budget radiobuttons and the selection round-trips into generated `LLM_init.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)